### PR TITLE
Upgrade filebeat from 1.3.1 to 5.4.2; send logs to Kafka instead of L…

### DIFF
--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -276,16 +276,15 @@ if [[ ! "$skip" = true ]]; then
   log_info 'finish setting up requests'
 
   log_info 'set up filebeat ...'
-  if [[ ! -f ${workspace_folder}/filebeat-1.3.1-${bitness}.tar.gz ]]; then
-    log_info "download filebeat-1.3.1-${bitness}.tar.gz"
-    wget -O ${workspace_folder}/filebeat-1.3.1-${bitness}.tar.gz https://download.elastic.co/beats/filebeat/filebeat-1.3.1-${bitness}.tar.gz
-    abort_if_failed "failed to download filebeat-1.3.1-${bitness}.tar.gz"
+  fb_tarball="filebeat-5.4.2-linux-${bitness}.tar.gz"
+  if [[ ! -f ${workspace_folder}/${fb_tarball} ]]; then
+    log_info "download ${fb_tarball}"
+    wget -P ${workspace_folder} https://artifacts.elastic.co/downloads/beats/filebeat/${fb_tarball}
+    abort_if_failed "failed to download ${fb_tarball}"
   fi
-  tar -xzf ${workspace_folder}/filebeat-1.3.1-${bitness}.tar.gz -C ${workspace_folder}
-  abort_if_failed "failed to extract tar -xzf ${workspace_folder}/filebeat-1.3.1-${bitness}.tar.gz -C ${workspace_folder}"
-  rm -rf ${workspace_folder}/filebeat-1.3.1
-  mv ${workspace_folder}/filebeat-1.3.1-${bitness} ${workspace_folder}/filebeat-1.3.1
-  abort_if_failed "failed to mv ${workspace_folder}/filebeat-1.3.1-${bitness} ${workspace_folder}/filebeat-1.3.1"
+  filebeat_folder=$(tar tfz ${workspace_folder}/${fb_tarball} | head -1 | sed -e 's/\/.*//')
+  tar -xzf ${workspace_folder}/${fb_tarball} -C ${workspace_folder}
+  abort_if_failed "failed to extract tar -xzf ${workspace_folder}/${fb_tarball} -C ${workspace_folder}"
 
   log_info 'set up jolokia'
   if [[ ! -f ${workspace_folder}/jolokia-jvm-1.3.5-agent.jar ]]; then
@@ -395,10 +394,14 @@ yes | cp -f -r "${basedir}/startup_scripts" "${agent_install_folder}/"
 abort_if_failed 'failed to copy startup scripts'
 
 log_info "set up filebeat"
-yes | cp -f -r "${workspace_folder}/filebeat-1.3.1" "${agent_install_folder}"
-yes | cp -f "${basedir}/filebeat.yml" "${agent_install_folder}/filebeat-1.3.1"
-yes | cp -f "${basedir}/filebeat.startup.sh" "${agent_install_folder}/filebeat-1.3.1"
-abort_if_failed "failed to copy ${workspace_folder}/filebeat-1.3.1 ${agent_install_folder}"
+yes | cp -f -r "${workspace_folder}/${filebeat_folder}" "${agent_install_folder}"
+yes | cp -f "${basedir}/filebeat.yml" "${agent_install_folder}/${filebeat_folder}"
+yes | cp -f "${basedir}/filebeat.startup.sh" "${agent_install_folder}/${filebeat_folder}"
+abort_if_failed "failed to copy ${workspace_folder}/${filebeat_folder} to ${agent_install_folder}"
+ln -s -f -T ${agent_install_folder}/${filebeat_folder} ${agent_install_folder}/filebeat
+abort_if_failed "failed to create/update symlink ${agent_install_folder}/filebeat"
+sed -i "s/<basedir>/${agent_install_folder_escaped}/g" "${agent_install_folder}/filebeat/filebeat.yml"
+abort_if_failed "failed to edit ${agent_install_folder}/filebeat/filebeat.yml"
 log_info "finish setting up filebeat"
 
 log_info "set up lib folder"

--- a/deploy/deploy_agent.sh
+++ b/deploy/deploy_agent.sh
@@ -66,7 +66,7 @@ function get_os() {
 }
 
 function usage() {
-  printf "sudo ORG_TOKEN=<token> CLIENT_ID=<id> [AGENT_URL=<agent-tarball_url> METRIC_SERVER_HOST=<server> ALERTD_SERVER=<alert_server:port>] deploy_agent.sh [-h] [-snmp] [-update]\n"
+  printf "sudo ORG_TOKEN=<token> CLIENT_ID=<id> SYSTEM_ID=<id> [AGENT_URL=<agent-tarball_url> METRIC_SERVER_HOST=<server> ALERTD_SERVER=<alert_server:port>] deploy_agent.sh [-h] [-snmp] [-update]\n"
 }
 
 if [ "$#" -gt 0 ]; then
@@ -97,6 +97,12 @@ fi
 
 if [ -z "${CLIENT_ID// }" ]; then
   echo "CLIENT_ID env variable is not set or empty"
+  usage
+  exit 1
+fi
+
+if [ -z "${SYSTEM_ID// }" ]; then
+  echo "SYSTEM_ID env variable is not set or empty"
   usage
   exit 1
 fi
@@ -160,9 +166,10 @@ sed -i "s/%PLATFORM%/$OS/g" ${agent_install_folder}/version.json
 abort_if_failed "failed to update PLATFORM in version.json"
 
 log_info "set filebeat home by default"
-sed -i "s/<token>/\"${ORG_TOKEN}\"/" ${agent_install_folder}/filebeat-1.3.1/filebeat.yml
-sed -i "s/<log-server-host-port>/\"${METRIC_SERVER_HOST}:5040\"/" ${agent_install_folder}/filebeat-1.3.1/filebeat.yml
-echo "FB_HOME=${agent_install_folder}/filebeat-1.3.1" > /etc/default/filebeat
+sed -i "s/<token>/\"${ORG_TOKEN}\"/" ${agent_install_folder}/filebeat/filebeat.yml
+sed -i "s/<orgid>/${CLIENT_ID}/" ${agent_install_folder}/filebeat/filebeat.yml
+sed -i "s/<sysid>/${SYSTEM_ID}/" ${agent_install_folder}/filebeat/filebeat.yml
+sed -i "s/<log-server-host-port>/\"${METRIC_SERVER_HOST}:9906\"/" ${agent_install_folder}/filebeat/filebeat.yml
 
 # install snmp, if needed
 if [[ "$snmp" = true ]]; then
@@ -222,11 +229,9 @@ if [ "$1" == "-update" ]; then
     yes | cp -rf ${working_folder}/conf ${agent_install_folder}/agent/collectors
     yes | rm -rf ${working_folder}/conf
     yes | cp -f  ${working_folder}/cloudwiz-agent-bk-${current_time}/agent/run ${agent_install_folder}/agent/
-    yes | cp -f  ${working_folder}/cloudwiz-agent-bk-${current_time}/filebeat-1.3.1/filebeat.yml ${agent_install_folder}/filebeat-1.3.1
-    yes | cp -f  ${working_folder}/cloudwiz-agent-bk-${current_time}/filebeat-1.3.1/filebeat.startup.sh ${agent_install_folder}/filebeat-1.3.1
+    yes | cp -f  ${working_folder}/cloudwiz-agent-bk-${current_time}/filebeat/filebeat.yml ${agent_install_folder}/filebeat
+    yes | cp -f  ${working_folder}/cloudwiz-agent-bk-${current_time}/filebeat/filebeat.startup.sh ${agent_install_folder}/filebeat
     yes | cp -f  ${working_folder}/cloudwiz-agent-bk-${current_time}/altenv/etc/supervisord.conf ${agent_install_folder}/altenv/etc/
-    echo "FB_HOME=${agent_install_folder}/filebeat-1.3.1" > /etc/default/filebeat
-    mkdir -p /var/log/filebeat
 fi
 # chown -hR "$agent_user" "${agent_install_folder}"
 # abort_if_failed "failed to change ownership of ${agent_install_folder}/download to $agent_user"

--- a/deploy/filebeat.startup.sh
+++ b/deploy/filebeat.startup.sh
@@ -23,8 +23,6 @@ export PATH
 
 name="filebeat"
 
-[ -r /etc/default/$name ] && . /etc/default/$name
-
 agent="$FB_HOME/filebeat"
 args="-c $FB_HOME/filebeat.yml"
 test_args="-e -configtest"

--- a/deploy/filebeat.yml
+++ b/deploy/filebeat.yml
@@ -1,97 +1,105 @@
-################### Filebeat Configuration Example #########################
+###################### Filebeat Configuration Example #########################
 
-############################# Filebeat ######################################
-filebeat:
-  # List of prospectors to fetch data.
-  prospectors:
-    # Each - is a prospector. Below are the prospector specific configurations
-    -
-      paths:
-        - /opt/cloudwiz-agent/altenv/var/log/collector.log
+# This file is an example configuration file highlighting only the most common
+# options. The filebeat.full.yml file from the same directory contains all the
+# supported options with more comments. You can use it as a reference.
+#
+# You can find the full configuration reference here:
+# https://www.elastic.co/guide/en/beats/filebeat/index.html
 
-      input_type: log
-      document_type: collector
-      fields:
-        token: "571145dfa339dc049c7467475cf82b1b115bca00"
-        org: "<org>"
-      fields_under_root: true
-      close_older: 2h
-      multiline:
-        pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3} '
-        negate: true
-        match: after
-    # Additional prospector
-    #-
-      # Configuration to use stdin input
-      #input_type: stdin
+#=========================== Filebeat prospectors =============================
 
-############################# Output ##########################################
+filebeat.prospectors:
+
+# Each - is a prospector. Most options can be set at the prospector level, so
+# you can use different prospectors for various configurations.
+# Below are the prospector specific configurations.
+
+- input_type: log
+
+  # Paths that should be crawled and fetched. Glob based paths.
+  paths:
+    - <basedir>/altenv/var/log/collector.log
+
+  document_type: collector
+  fields.client: <orgid>
+  fields.orgid: 2
+  fields.sysid: 15
+  fields.token: "571145dfa339dc049c7467475cf82b1b115bca00"
+  fields_under_root: true
+  close_inactive: 2h
+  tail_files: true
+  multiline.pattern: '^[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2},[0-9]{3} '
+  multiline.negate: true
+  multiline.match: after
+
+- input_type: log
+
+  # Paths that should be crawled and fetched. Glob based paths.
+  paths:
+    - /var/log/messages
+
+  document_type: system
+  fields.orgid: <orgid>
+  fields.sysid: <sysid>
+  fields.token: <token>
+  fields_under_root: true
+  close_inactive: 2h
+  tail_files: true
+  multiline.pattern: '^[a-zA-Z]{3}[ ]{1,2}[0-9]{1,2} [0-9]{2}:[0-9]{2}:[0-9]{2} '
+  multiline.negate: true
+  multiline.match: after
+
+
+#================================ General =====================================
+
+# The name of the shipper that publishes the network data. It can be used to group
+# all the transactions sent by a single shipper in the web interface.
+#name:
+
+# The tags of the shipper are included in their own field with each
+# transaction published.
+#tags: ["service-X", "web-tier"]
+
+# Optional fields that you can specify to add additional information to the
+# output.
+#fields:
+#  env: staging
+
+#================================ Outputs =====================================
 
 # Configure what outputs to use when sending the data collected by the beat.
 # Multiple outputs may be used.
-output:
 
-  ### Logstash as output
-  logstash:
-    # The Logstash hosts
-    hosts: [<log-server-host-port>]
+#-------------------------- Kafka output ------------------------------
+output.kafka:
+  # Array of hosts to connect to.
+  hosts: [<log-server-host-port>]
+  ssl.enabled: true
+  version: "0.10"
+  topic: 'filebeat.%{[orgid]}.%{[sysid]}'
+  partition.round_robin:
+    reachable_only: true
+  required_acks: 1
+  compression: gzip
+  max_message_bytes: 1000000
 
-    # Number of workers per Logstash host.
-    #worker: 1
 
-    # The maximum number of events to bulk into a single batch window. The
-    # default is 2048.
-    #bulk_max_size: 2048
+#================================ Logging =====================================
 
-    # Set gzip compression level.
-    #compression_level: 3
+# Sets log level. The default log level is info.
+# Available log levels are: critical, error, warning, info, debug
+#logging.level: debug
 
-    # Optional load balance the events between the Logstash hosts
-    loadbalance: true
+# At debug level, you can selectively enable logging only for some components.
+# To enable all selectors use ["*"]. Examples of other selectors are "beat",
+# "publish", "service".
+#logging.selectors: ["*"]
 
-    # Optional index name. The default index name depends on the each beat.
-    # For Packetbeat, the default is set to packetbeat, for Topbeat
-    # top topbeat and for Filebeat to filebeat.
-    #index: filebeat
-
-    tls:
-
-############################# Logging #########################################
-
-# There are three options for the log ouput: syslog, file, stderr.
-# Under Windos systems, the log files are per default sent to the file output,
-# under all other system per default to syslog.
-logging:
-
-  # Send all logging output to syslog. On Windows default is false, otherwise
-  # default is true.
-  to_syslog: false
-
-  # Write all logging output to files. Beats automatically rotate files if rotateeverybytes
-  # limit is reached.
-  to_files: true
-
-  # To enable logging to files, to_files option has to be set to true
-  files:
-    # The directory where the log files will written to.
-    path: /var/log/filebeat
-
-    # The name of the files where the logs are written to.
-    name: filebeat.log
-
-    # Configure log file size limit. If limit is reached, log file will be
-    # automatically rotated
-    rotateeverybytes: 10485760 # = 10MB
-
-    # Number of rotated log files to keep. Oldest files will be deleted first.
-    #keepfiles: 7
-
-  # Enable debug output for selected components. To enable all selectors use ["*"]
-  # Other available selectors are beat, publish, service
-  # Multiple selectors can be chained.
-  #selectors: [ ]
-
-  # Sets log level. The default log level is error.
-  # Available log levels are: critical, error, warning, info, debug
-  level: info
-
+logging.level: info
+logging.to_files: true
+logging.to_syslog: false
+logging.files:
+  path: <basedir>/altenv/var/log
+  name: filebeat.log
+  keepfiles: 4

--- a/deploy/supervisord.conf
+++ b/deploy/supervisord.conf
@@ -64,12 +64,12 @@ stopasgroup=true
 environment=PYTHON_EGG_CACHE=<basedir>/altenv/var/cache
 
 [program:filebeat]
-command=<basedir>/filebeat-1.3.1/filebeat.startup.sh
+command=<basedir>/filebeat/filebeat.startup.sh
 autorestart=true
 startsecs=5
 startretries=3
 stopasgroup=true
-environment=FB_HOME=<basedir>
+environment=FB_HOME=<basedir>/filebeat
 
 
 [group:cloudwiz-agent]


### PR DESCRIPTION
Upgrade filebeat from version 1.3.1 to 5.4.2. Also changed the destination of log files from Logstash to Kafka.

**Note that this change requires that deploy_agent.sh scripts be passed in an additional SYSTEM_ID. This is NOT currently passed in.**